### PR TITLE
Update as.mcmc.hmsc.R

### DIFF
--- a/R/as.mcmc.hmsc.R
+++ b/R/as.mcmc.hmsc.R
@@ -151,7 +151,7 @@ function(x, parameters = NULL, burning = FALSE, ...){
 			paramBurnMCMC <- x$results$burning[[parameters]]
 			rownames(paramBurnMCMC) <- rownames(x$results$burning[[parameters]])
 			colnames(paramBurnMCMC) <- colnames(x$results$burning[[parameters]])
-			paramMCMCMat <- rbind(paramBurnMCMCMat,paramMCMCMat)
+			paramMCMCMat <- rbind(paramBurnMCMC,paramMCMCMat)
 		}
 	}
 


### PR DESCRIPTION
Line 154... Don't know if there is a new matrix paramBurnMCMCMat that wasn't created, or there was just an error in the original name

This is a bug in the as.mcmc() function when the parameters are set to "meansParamX", the error:

> Error in rbind(paramBurnMCMCMat, paramMCMCMat) : 
>   object 'paramBurnMCMCMat' not found